### PR TITLE
Sanitize trim($year) input to avoid PHP warning

### DIFF
--- a/iCalcreator.class.php
+++ b/iCalcreator.class.php
@@ -8357,7 +8357,7 @@ class iCalUtilityFunctions {
       }
       $input['value']  = iCalUtilityFunctions::_timestamp2date( $year, $parno );
     } // end elseif( iCalUtilityFunctions::_isArrayTimestampDate( $year ))
-    elseif( 8 <= strlen( trim( $year ))) { // ex. 2006-08-03 10:12:18 [[[+/-]1234[56]] / timezone]
+    elseif( is_string( $year ) && (8 <= strlen( trim( $year )))) { // ex. 2006-08-03 10:12:18 [[[+/-]1234[56]] / timezone]
       if( $localtime )
         unset( $month['VALUE'], $month['TZID'] );
       elseif( !isset( $month['TZID'] ) && !empty( $tzid ))
@@ -8518,7 +8518,7 @@ class iCalUtilityFunctions {
       $input['params'] = iCalUtilityFunctions::_setParams( $month, array( 'VALUE' => 'DATE-TIME' ));
       unset( $input['params']['VALUE'], $input['params']['TZID']  );
     }
-    elseif( 8 <= strlen( trim( $year ))) { // ex. 2006-08-03 10:12:18
+    elseif( is_string( $year ) && (8 <= strlen( trim( $year )))) { // ex. 2006-08-03 10:12:18
       $input['value']  = iCalUtilityFunctions::_strdate2date( $year, 7 );
       unset( $input['value']['unparsedtext'] );
       $input['params'] = iCalUtilityFunctions::_setParams( $month, array( 'VALUE' => 'DATE-TIME' ));


### PR DESCRIPTION
to avoid php warning that may lead, depending on php configuration, to tainting of the served page/request output with the above warning:

```
ERROR - 2015-01-17 08:30:29 --> Severity: Warning  --> trim() expects parameter 1 to be string, array given /var/www/agendav/libs/icalcreator/iCalcreator.class.php 8639
```