### PR TITLE
rename constructors to __construct

### DIFF
--- a/lib/calendarComponent.class.php
+++ b/lib/calendarComponent.class.php
@@ -58,7 +58,7 @@ class calendarComponent  extends iCalBase {
  * @uses calendarComponent::_createFormat()
  * @uses calendarComponent::_makeDtstamp()
  */
-  function calendarComponent() {
+  function __construct() {
     $this->objName         = ( isset( $this->timezonetype )) ?
                           strtolower( $this->timezonetype )  :  get_class ( $this );
     $this->uid             = array();

--- a/lib/valarm.class.php
+++ b/lib/valarm.class.php
@@ -70,8 +70,8 @@ class valarm extends calendarComponent {
  * @uses valarm::$xprop
  * @uses calendarComponent::setConfig()
  */
-  function valarm( $config = array()) {
-    $this->calendarComponent();
+  function __construct( $config = array()) {
+    parent::__construct();
     $this->action          = '';
     $this->attach          = '';
     $this->attendee        = '';

--- a/lib/vcalendar.class.php
+++ b/lib/vcalendar.class.php
@@ -90,7 +90,7 @@ class vcalendar extends iCalBase {
  * @uses vcalendar::$xcaldecl
  * @uses vcalendar::$components
  */
-  function vcalendar ( $config = array()) {
+  function __construct ( $config = array()) {
     $this->_makeVersion();
     $this->calscale   = null;
     $this->method     = null;

--- a/lib/vevent.class.php
+++ b/lib/vevent.class.php
@@ -134,8 +134,8 @@ class vevent extends calendarComponent {
  * @uses vevent::$components
  * @uses calendarComponent::setConfig()
  */
-  function vevent( $config = array()) {
-    $this->calendarComponent();
+  function __construct( $config = array()) {
+    parent::__construct();
     $this->attach          = '';
     $this->attendee        = '';
     $this->categories      = '';

--- a/lib/vfreebusy.class.php
+++ b/lib/vfreebusy.class.php
@@ -75,8 +75,8 @@ class vfreebusy extends calendarComponent {
  * @uses vjournal::$xprop
  * @uses calendarComponent::setConfig()
  */
-  function vfreebusy( $config = array()) {
-    $this->calendarComponent();
+  function __construct( $config = array()) {
+    parent::__construct();
     $this->attendee        = '';
     $this->comment         = '';
     $this->contact         = '';

--- a/lib/vjournal.class.php
+++ b/lib/vjournal.class.php
@@ -112,8 +112,8 @@ class vjournal extends calendarComponent {
  * @uses vjournal::$xprop
  * @uses calendarComponent::setConfig()
  */
-  function vjournal( $config = array()) {
-    $this->calendarComponent();
+  function __construct( $config = array()) {
+    parent::__construct();
     $this->attach          = '';
     $this->attendee        = '';
     $this->categories      = '';

--- a/lib/vtimezone.class.php
+++ b/lib/vtimezone.class.php
@@ -81,7 +81,7 @@ class vtimezone extends calendarComponent {
  * @uses vtimezone::$components
  * @uses calendarComponent::setConfig()
  */
-  function vtimezone( $timezonetype=FALSE, $config = array()) {
+  function __construct( $timezonetype=FALSE, $config = array()) {
     if( is_array( $timezonetype )) {
       $config       = $timezonetype;
       $timezonetype = FALSE;
@@ -90,7 +90,7 @@ class vtimezone extends calendarComponent {
       $this->timezonetype = 'VTIMEZONE';
     else
       $this->timezonetype = strtoupper( $timezonetype );
-    $this->calendarComponent();
+    parent::__construct();
     $this->comment         = '';
     $this->dtstart         = '';
     $this->lastmodified    = '';

--- a/lib/vtodo.class.php
+++ b/lib/vtodo.class.php
@@ -137,8 +137,8 @@ class vtodo extends calendarComponent {
  * @uses vtodo::$components
  * @uses calendarComponent::setConfig()
  */
-  function vtodo( $config = array()) {
-    $this->calendarComponent();
+  function __construct( $config = array()) {
+    parent::__construct();
     $this->attach          = '';
     $this->attendee        = '';
     $this->categories      = '';


### PR DESCRIPTION
Because using the class name for the constructor is deprecated as of PHP7