### PR TITLE
Fix 'must be an array or an object that implements Countable' warnings

### DIFF
--- a/src/util/util.php
+++ b/src/util/util.php
@@ -488,7 +488,7 @@ class util {
                                      $preSet=null ) {
     if( $preSet )
       return $preSet;
-    if( ( 0 == count( $array )) || ! is_array( $array ))
+    if( ! is_array( $array ) || ( 0 == count( $array )) )
       return $elseVal;
     foreach( $array as $key => $value ) {
       if( 0 == strcasecmp( $expkey, $key )) {

--- a/src/util/utilRexdate.php
+++ b/src/util/utilRexdate.php
@@ -175,8 +175,10 @@ class utilRexdate {
  */
   public static function prepInputExdate( $exdates, $params=null ) {
     static $GMTUTCZARR = ['GMT', 'UTC', 'Z'];
-    $input  = [util::$LCparams => util::setParams( $params,
-                                                   util::$DEFAULTVALUEDATETIME )];
+    $input = [
+      util::$LCparams => util::setParams( $params, util::$DEFAULTVALUEDATETIME ),
+      util::$LCvalue => []
+    ];
     $toZ = ( isset( $input[util::$LCparams][util::$TZID] ) &&
              in_array( strtoupper( $input[util::$LCparams][util::$TZID] ),
                        $GMTUTCZARR ))

--- a/src/util/utilSelect.php
+++ b/src/util/utilSelect.php
@@ -544,7 +544,7 @@ class utilSelect {
       else
         ksort( $result );
     } // end elseif( !$flat )
-    if( 0 >= count( $result ))
+    if( !is_null($result) && 0 >= count( $result ))
       return false;
     return $result;
   }


### PR DESCRIPTION
Got a couple of warnings when running this with PHP 7.2 that the argument
to count() must be an array or a Countable object. These were the ones I
ran into, might be more.