### PR TITLE
Fix default for unique id config

### DIFF
--- a/src/IcalBase.php
+++ b/src/IcalBase.php
@@ -299,7 +299,7 @@ abstract class IcalBase implements IcalInterface
             if( false !== ( $cfg = $this->getConfig( self::LANGUAGE ))) {
                 $output[self::LANGUAGE]  = $cfg;
             }
-            $output[self::UNIQUE_ID]     = $this->getConfig( self::UNIQUE_ID );
+            $output[self::UNIQUE_ID]     = $this->getConfig( self::UNIQUE_ID ) ?: '';
             return $output;
         }
         switch( strtoupper( $config )) {


### PR DESCRIPTION
If no unique id is present, `getConfig` will return `false`. This is not accepted by `setConfig`, since it calls `trim`. Therefore, a default value of an empty string is better.
Use case: creating a new `Vtimezone` without unique id, then add a `Standard` to it.