### PR TITLE
Reintroduce array value support for setConfig

### DIFF
--- a/src/IcalBase.php
+++ b/src/IcalBase.php
@@ -407,7 +407,7 @@ abstract class IcalBase implements IcalInterface
      */
     public function setConfig(
         string | array $config,
-        null|bool|string $value = null ,
+        null|bool|string|array $value = null ,
         ? bool $softUpdate = false
     ) : static
     {


### PR DESCRIPTION
The change from `mixed` to `null|bool|string` broke our iCal exports, specifically for the timezone definitions.