### PR TITLE
Fix exdates can be an array

### DIFF
--- a/src/Traits/EXDATEtrait.php
+++ b/src/Traits/EXDATEtrait.php
@@ -92,10 +92,10 @@ trait EXDATEtrait
      *
      * @param null|int    $propIx specific property in case of multiply occurrence
      * @param null|bool   $inclParam
-     * @return bool|string|Pc
+     * @return bool|string|array|Pc
      * @since 2.41.36 2022-04-03
      */
-    public function getExdate( ? int $propIx = null, ? bool $inclParam = false ) : bool | string | Pc
+    public function getExdate( ? int $propIx = null, ? bool $inclParam = false ) : bool | string | array | Pc
     {
         if( empty( $this->exdate )) {
             unset( $this->propIx[self::EXDATE] );


### PR DESCRIPTION
I have a google calendar with multiples exdates like this: 
```
EXDATE;TZID=Europe/Berlin:20220508T183000
EXDATE;TZID=Europe/Berlin:20220501T183000
```

I'm not sure if the return of the array is because of that or if there is something else wrong 🤔 
