### PR TITLE
Cast ctype_digit() arguments to string

### DIFF
--- a/src/Util/SortFactory.php
+++ b/src/Util/SortFactory.php
@@ -79,10 +79,10 @@ class SortFactory
             if( empty( $b->srtk[$k] )) {
                 return 1;
             }
-            $aKey = ctype_digit( $a->srtk[$k] )
+            $aKey = ctype_digit( (string) $a->srtk[$k] )
                 ? str_pad((string) $a->srtk[$k], 20, '0', STR_PAD_LEFT )
                 : (string) $a->srtk[$k];
-            $bKey = ctype_digit( $b->srtk[$k] )
+            $bKey = ctype_digit( (string) $b->srtk[$k] )
                 ? str_pad((string) $b->srtk[$k], 20, '0', STR_PAD_LEFT )
                 : (string)$b->srtk[$k];
             $sortStat = strcmp( $aKey, $bKey );


### PR DESCRIPTION
Fixes warnings:
```
  PHP Deprecated:  ctype_digit(): Argument of type int will be interpreted as string in the future in src/Util/SortFactory.php on line 82
  PHP Deprecated:  ctype_digit(): Argument of type int will be interpreted as string in the future in src/Util/SortFactory.php on line 85
```

I think there may be a few more `ctype_digit()` calls that need casting but these are the ones that I have hit.