### PR TITLE
Implicitly marking parameter as nullable is deprecated in PHP 8.4

### DIFF
--- a/src/Traits/COMMENTtrait.php
+++ b/src/Traits/COMMENTtrait.php
@@ -91,7 +91,7 @@ trait COMMENTtrait
      * @return bool|string|Pc
      * @since 2.41.36 2022-04-03
      */
-    public function getComment( int $propIx = null, bool $inclParam = false ) : bool | string | Pc
+    public function getComment( ?int $propIx = null, bool $inclParam = false ) : bool | string | Pc
     {
         if( empty( $this->comment )) {
             unset( $this->propIx[self::COMMENT] );

--- a/src/Traits/STRUCTURED_DATArfc9073trait.php
+++ b/src/Traits/STRUCTURED_DATArfc9073trait.php
@@ -87,7 +87,7 @@ trait STRUCTURED_DATArfc9073trait
      * @param bool $inclParam
      * @return bool|string|Pc
      */
-    public function getStructureddata( int $propIx = null, bool $inclParam = false ) : bool | string |Pc
+    public function getStructureddata( ?int $propIx = null, bool $inclParam = false ) : bool | string |Pc
     {
         if( empty( $this->structureddata )) {
             unset( $this->propIx[self::STRUCTURED_DATA] );

--- a/src/Traits/STYLED_DESCRIPTIONrfc9073trait.php
+++ b/src/Traits/STYLED_DESCRIPTIONrfc9073trait.php
@@ -88,7 +88,7 @@ trait STYLED_DESCRIPTIONrfc9073trait
      * @param bool $inclParam
      * @return bool|string|Pc
      */
-    public function getStyleddescription( int $propIx = null, bool $inclParam = false ) : bool | string | Pc
+    public function getStyleddescription( ?int $propIx = null, bool $inclParam = false ) : bool | string | Pc
     {
         if( empty( $this->styleddescription )) {
             unset( $this->propIx[self::STYLED_DESCRIPTION] );

--- a/src/Traits/TZID_ALIAS_OFrfc7808trait.php
+++ b/src/Traits/TZID_ALIAS_OFrfc7808trait.php
@@ -89,7 +89,7 @@ trait TZID_ALIAS_OFrfc7808trait
      * @return bool|string|Pc
      * @since 2.41.36 2022-04-03
      */
-    public function getTzidaliasof( int $propIx = null, bool $inclParam = false ) : bool | string | Pc
+    public function getTzidaliasof( ?int $propIx = null, bool $inclParam = false ) : bool | string | Pc
     {
         if( empty( $this->tzidaliasof )) {
             unset( $this->propIx[self::TZID_ALIAS_OF] );


### PR DESCRIPTION
This improves compatibility with PHP 8.4