### PR TITLE
fix: utf8_encode() is deprecated

### DIFF
--- a/src/Util/HttpFactory.php
+++ b/src/Util/HttpFactory.php
@@ -48,7 +48,7 @@ use function substr;
 use function sys_get_temp_dir;
 use function tempnam;
 use function unlink;
-use function utf8_encode;
+use function mb_convert_encoding;
 
 /**
  * iCalcreator http support class
@@ -98,7 +98,7 @@ class HttpFactory
         }
         $output     = $calendar->createCalendar();
         if( $utf8Encode ?? false ) {
-            $output = utf8_encode( $output );
+            $output = mb_convert_encoding( $output, 'UTF-8', 'auto' );
         }
         $fsize = null;
         if( $gzip ?? false ) {


### PR DESCRIPTION
This commit fixes the following warning:

`PHP Deprecated:  Function utf8_encode() is deprecated in /lib/vendor/iCalcreator/src/Util/HttpFactory.php on line 101`